### PR TITLE
Update text-to-image.mdx - Fixed LoRA field name in CURL command.

### DIFF
--- a/ai/pipelines/text-to-image.mdx
+++ b/ai/pipelines/text-to-image.mdx
@@ -138,7 +138,7 @@ curl -X POST "https://<GATEWAY_IP>/text-to-image" \
         "prompt":"A cool cat on the beach",
         "width": 1024,
         "height": 1024,
-        "loras": "{ \"latent-consistency/lcm-lora-sdxl\": 1.0, \"nerijs/pixel-art-xl\": 1.2}"
+        "lora_models": "{ \"latent-consistency/lcm-lora-sdxl\": 1.0, \"nerijs/pixel-art-xl\": 1.2}"
     }'
 ```
 


### PR DESCRIPTION
IMPORTANT: At least one orchestrator (Marco) claims that `loras` is the right field name, while HuggingFace uses `lora_models`.  It may be better to wait on this pull request until this gets sussed out.   I do not for a fact though, that when I use `loras` I get a 503 Service Unvailable error.  Marco hypothesizes that perhaps `loras` doesn't get the 503 error is perhaps because invalid field names are ignored, but I can not confirm this.

ORIGINAL COMMENT: The correct field name for the LoRA models field in a request body is `lora_models` not `loras`.  If you use `lora`, you will get a 503 Service Unavailable error.